### PR TITLE
Default values for OCCI_INCLUDE_DIR and OCCI_LIB_DIR in bindings.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,8 @@
     {
       "target_name": "oracle_bindings",
       "variables": {
-         "oci_include_dir%": "<!(echo $OCI_INCLUDE_DIR)",
-         "oci_lib_dir%": "<!(echo $OCI_LIB_DIR)"
+         "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
+         "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
       },
       "sources": [ "src/connection.cpp", 
                    "src/oracle_bindings.cpp", 


### PR DESCRIPTION
...nding.gyp (so if you don't have OCCI_INCLUDE_DIR and OCCI_LIB_DIR set in your environment, the default oracle locations will be used..
