### PR TITLE
Fix variables in binding.gyp and add Windows defaults

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,8 +22,8 @@
         }],
         ["OS=='win'", {
           "variables": {
-            "oci_include_dir%": "<!(echo %OCI_INCLUDE_DIR%)",
-            "oci_lib_dir%": "<!(echo %OCI_LIB_DIR%)"
+            "oci_include_dir%": "<!(IF DEFINED OCI_INCLUDE_DIR (echo %OCI_INCLUDE_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include))",
+            "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
          },
          # "libraries": [ "-loci" ],
          "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci11.lib'] }


### PR DESCRIPTION
Properly fixed the merge conflict that resulted between pull requests #34 and #29 (relating to where the variables are set in binding.gyp.)  Also added some default values for OCCI_INCLUDE_DIR and OCCI_LIB_DIR on Windows.
