### PR TITLE
Support for TNS-strings

### DIFF
--- a/src/oracle_bindings.cpp
+++ b/src/oracle_bindings.cpp
@@ -12,6 +12,7 @@ struct connect_baton_t {
   std::string user;
   std::string password;
   std::string database;
+  std::string tns;
   uint32_t port;
   oracle::occi::Environment *environment;
 
@@ -65,6 +66,7 @@ Handle<Value> OracleClient::Connect(const Arguments& args) {
   OBJ_GET_STRING(settings, "password", baton->password);
   OBJ_GET_STRING(settings, "database", baton->database);
   OBJ_GET_NUMBER(settings, "port", baton->port, 1521);
+  OBJ_GET_STRING(settings, "tns", baton->tns);
 
   client->Ref();
 
@@ -82,7 +84,11 @@ void OracleClient::EIO_Connect(uv_work_t* req) {
 
   try {
     std::ostringstream connectionStr;
-    connectionStr << "//" << baton->hostname << ":" << baton->port << "/" << baton->database;
+    if (baton->tns != "") {
+      connectionStr << baton->tns;
+    } else {
+      connectionStr << "//" << baton->hostname << ":" << baton->port << "/" << baton->database;
+    }
     baton->connection = baton->environment->createConnection(baton->user, baton->password, connectionStr.str());
   } catch(oracle::occi::SQLException &ex) {
     baton->error = new std::string(ex.getMessage());


### PR DESCRIPTION
Adds support for TNS-strings like

```
(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=MyHost)(PORT=MyPort)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=MyOracleSID)))
```

instead of using hostname + database. This should make it possible to connect to almost any oracle database, including all the features TNS brings.

Connect looks like this:

```
var oracle = require("oracle");

oracle.connect({
    "tns": "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=MyHost)(PORT=MyPort)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=MyOracleSID)))",
    "user": "test",
    "password": "test"
}, function(err, connection) {
    ...
}
```
