### PR TITLE
Implement connection.isConnected(), don't segfault when doing work on closed connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ oracle.connect(connData, function(err, connection) {
 });
 ```
 
+To validate whether the connection is still established after some time:
+
+```javascript
+if (! connection.isConnected()) {
+  // retire this connection from a pool
+}
+```
 
 
 ## Out Params

--- a/src/connection.h
+++ b/src/connection.h
@@ -22,6 +22,7 @@ public:
   static Handle<Value> New(const Arguments& args);
   static Handle<Value> Execute(const Arguments& args);
   static Handle<Value> Close(const Arguments& args);
+  static Handle<Value> IsConnected(const Arguments& args);
   static Handle<Value> Commit(const Arguments& args);
   static Handle<Value> Rollback(const Arguments& args);
   static Handle<Value> SetAutoCommit(const Arguments& args);


### PR DESCRIPTION
We need to be able to detect closed connections so that we can more easily integrate with generic-pool.  That module
has a validate() hook which pairs nicely with the connection.isConnected() change I'm proposing here.

Test scenario for reproing segfault issue:
- Open connection
- Set timer for closing connection with connection.close() after 10 seconds
- Wait for timer to activate and close connection
- Try to run connection.execute('SELECT 1 FROM DUAL')
- Segfault occurs
- After this change, it will throw an error instead of segfaulting
