### PR TITLE
Handle exceptions within callback functions by calling node::FatalException()

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -347,7 +347,11 @@ void Connection::EIO_AfterCommit(uv_work_t* req, int status) {
 
   Handle<Value> argv[2];
   argv[0] = Undefined();
+  v8::TryCatch tryCatch;
   baton->callback->Call(Context::GetCurrent()->Global(), 1, argv);
+  if (tryCatch.HasCaught()) {
+    node::FatalException(tryCatch);
+  }
 
   delete baton;
 }
@@ -365,7 +369,11 @@ void Connection::EIO_AfterRollback(uv_work_t* req, int status) {
 
   Handle<Value> argv[2];
   argv[0] = Undefined();
+  v8::TryCatch tryCatch;
   baton->callback->Call(Context::GetCurrent()->Global(), 1, argv);
+  if (tryCatch.HasCaught()) {
+    node::FatalException(tryCatch);
+  }
 
   delete baton;
 }
@@ -715,7 +723,11 @@ void Connection::EIO_AfterExecute(uv_work_t* req, int status) {
         argv[1] = obj;
       }
     }
+    v8::TryCatch tryCatch;
     baton->callback->Call(Context::GetCurrent()->Global(), 2, argv);
+    if (tryCatch.HasCaught()) {
+      node::FatalException(tryCatch);
+    }
   } catch(NodeOracleException &ex) {
     Handle<Value> argv[2];
     argv[0] = Exception::Error(String::New(ex.getMessage().c_str()));

--- a/src/oracle_bindings.cpp
+++ b/src/oracle_bindings.cpp
@@ -111,7 +111,11 @@ void OracleClient::EIO_AfterConnect(uv_work_t* req, int status) {
     argv[1] = connection;
   }
 
+  v8::TryCatch tryCatch;
   baton->callback->Call(Context::GetCurrent()->Global(), 2, argv);
+  if (tryCatch.HasCaught()) {
+    node::FatalException(tryCatch);
+  }
 
   baton->callback.Dispose();
   if(baton->error) delete baton->error;


### PR DESCRIPTION
These changes address the fact that in callbacks passed to the node-oracle functions, uncaught exceptions are handled however V8 wants to handle them, and are not catcheable in the javascript:

``` javascript
oracle.connect(settings, function(err, connection) {
  try {
    connection.execute(query, [], function(err, results) {
      undefined.trim(); // Exception thrown by this line is handled in V8 land; node is unaware
      return results;
    });
  } catch (ex) {
    console.error(ex); // never hit
  }
});
```

Using `v8::TryCatch` allows us to return the exception as a `node::FatalException`.  For another example, see: https://github.com/kkaefer/node-cpp-modules/blob/master/05_threadpool/modulename.cpp
