### PR TITLE
Allow user to specify Instant Client version with OCI_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ On MacOS or Linux:
 
 MacOS/Linux:
 
-```
+```bash
 export OCI_HOME=<directory of Oracle instant client>
 export OCI_LIB_DIR=$OCI_HOME
 export OCI_INCLUDE_DIR=$OCI_HOME/sdk/include
+export OCI_VERSION=<the instant client major version number> # Optional. Default is 11.
 ```
 
 2. Create the following symbolic links
@@ -78,9 +79,10 @@ On Windows, you need to set the environment variables:
 
 If you have VisualStudio 2012 installed,
 
-```
+```bat
 OCI_INCLUDE_DIR=C:\instantclient_12_1\sdk\include
 OCI_LIB_DIR=C:\instantclient_12_1\sdk\lib\msvc\vc11
+OCI_VERSION=<the instant client major version number> # Optional. Default is 11.
 Path=...;c:\instantclient_12_1\vc11;c:\instantclient_12_1
 ```
 
@@ -88,9 +90,10 @@ Path=...;c:\instantclient_12_1\vc11;c:\instantclient_12_1
 
 If you have VisualStudio 2010 installed,
 
-```
+```bat
 OCI_INCLUDE_DIR=C:\instantclient_12_1\sdk\include
 OCI_LIB_DIR=C:\instantclient_12_1\sdk\lib\msvc\vc10
+OCI_VERSION=<the instant client major version number> # Optional. Default is 11.
 Path=...;c:\instantclient_12_1\vc10;c:\instantclient_12_1
 ```
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,20 +10,15 @@
         ["OS=='mac'", {
           "xcode_settings": {
             "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
-          },
-          "variables": {
-			 "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
-			 "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
-          },
-          "libraries": [ "-locci", "-lclntsh", "-lnnz11" ],
-          "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
+          }
         }],
-        ["OS=='linux'", {
+        ["OS!='win'", {
           "variables": {
 			 "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
 			 "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
+			 "oci_version%": "<!(if [ -z $OCI_VERSION ]; then echo 11; else echo $OCI_VERSION; fi)"
           },
-          "libraries": [ "-locci", "-lclntsh", "-lnnz12" ],
+          "libraries": [ "-locci", "-lclntsh", "-lnnz<(oci_version)" ],
           "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
         }],
         ["OS=='win'", {
@@ -46,9 +41,10 @@
           "variables": {
             "oci_include_dir%": "<!(IF DEFINED OCI_INCLUDE_DIR (echo %OCI_INCLUDE_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include))",
             "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
+            "oci_version%": "<!(IF DEFINED OCI_VERSION (echo %OCI_VERSION%) ELSE (echo 11))"
          },
          # "libraries": [ "-loci" ],
-         "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci12.lib'] }
+         "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci<(OCI_VERSION).lib'] }
         }]
       ],
       "include_dirs": [ "<(oci_include_dir)" ],


### PR DESCRIPTION
Fixes https://github.com/nearinfinity/node-oracle/issues/69.  By default the module will link against the Oracle Instant Client 11.x.  To override it, simply set the environment variable "OCI_VERSION."  Also updated the docs.
