### PR TITLE
Catch close exception

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -149,13 +149,13 @@ Handle<Value> Connection::SetAutoCommit(const Arguments& args) {
 
 void Connection::closeConnection() {
   if(m_environment && m_connection) {
-  	try {
-		m_environment->terminateConnection(m_connection);
-		m_connection = NULL;
-	} catch (oracle::occi::SQLException &ex) {
-		m_connection = NULL;
-		throw; // rethrow to allow handler to throw in V8 scope
-	}
+    try {
+      m_environment->terminateConnection(m_connection);
+      m_connection = NULL;
+    } catch (oracle::occi::SQLException &ex) {
+      m_connection = NULL;
+      throw; // rethrow to allow caller to catch and rethrow in V8 scope
+    }
   }
 }
 


### PR DESCRIPTION
This closes issue #74 which is that an oracle exception in closeConnection() crashes the process when called by the destructor.

This fix might possibly create a memory leak if the exception is caught and ignored in Javascript, since the resources allocated to the `m_connection` are left in an unknown state.  I did not see any evidence of a leak when using valgrind, but I'm not very experienced with that tool, either.  In any case, as raymondfeng in #74 points out, a leak caused by an exception in terminateConnection() would be an OCCI bug.
