### PR TITLE
added setPrefetchRowCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ connection.execute("call myProc(:1)", [new oracle.OutParam(oracle.OCCIINT, {in: 
 ```
 
 
+## Connection options
+
+The following options can be set on the connection:
+
+```
+connection.setAutoCommit(true/false);
+connection.setPrefetchRowCount(count);
+```
+
 # Develop
 
 ## Install Oracle/Oracle Express

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -25,6 +25,7 @@ void Connection::Init(Handle<Object> target) {
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "close", Close);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isConnected", IsConnected);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "setAutoCommit", SetAutoCommit);
+  NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "setPrefetchRowCount", SetPrefetchRowCount);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "commit", Commit);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "rollback", Rollback);
 
@@ -39,7 +40,7 @@ Handle<Value> Connection::New(const Arguments& args) {
   return scope.Close(args.This());
 }
 
-Connection::Connection():m_connection(NULL), m_environment(NULL), m_autoCommit(true) {
+Connection::Connection():m_connection(NULL), m_environment(NULL), m_autoCommit(true), m_prefetchRowCount(0) {
 }
 
 Connection::~Connection() {
@@ -144,6 +145,14 @@ Handle<Value> Connection::SetAutoCommit(const Arguments& args) {
   Connection* connection = ObjectWrap::Unwrap<Connection>(args.This());
   REQ_BOOL_ARG(0, autoCommit);
   connection->m_autoCommit = autoCommit;
+  return scope.Close(Undefined());
+}
+
+Handle<Value> Connection::SetPrefetchRowCount(const Arguments& args) {
+  HandleScope scope;
+  Connection* connection = ObjectWrap::Unwrap<Connection>(args.This());
+  REQ_INT_ARG(0, prefetchRowCount);
+  connection->m_prefetchRowCount = prefetchRowCount;
   return scope.Close(Undefined());
 }
 
@@ -396,6 +405,7 @@ void Connection::EIO_Execute(uv_work_t* req) {
     }
     stmt = baton->connection->m_connection->createStatement(baton->sql);
     stmt->setAutoCommit(baton->connection->m_autoCommit);
+    if (baton->connection->m_prefetchRowCount > 0) stmt->setPrefetchRowCount(baton->connection->m_prefetchRowCount);
     int outputParam = SetValuesOnStatement(stmt, baton->values);
 
     int status = stmt->execute();

--- a/src/connection.h
+++ b/src/connection.h
@@ -27,6 +27,7 @@ public:
   static Handle<Value> Commit(const Arguments& args);
   static Handle<Value> Rollback(const Arguments& args);
   static Handle<Value> SetAutoCommit(const Arguments& args);
+  static Handle<Value> SetPrefetchRowCount(const Arguments& args);
   static Persistent<FunctionTemplate> constructorTemplate;
   static void EIO_Execute(uv_work_t* req);
   static void EIO_AfterExecute(uv_work_t* req, int status);
@@ -53,6 +54,7 @@ private:
   oracle::occi::Connection* m_connection;
   oracle::occi::Environment* m_environment;
   bool m_autoCommit;
+  int m_prefetchRowCount;
 };
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,6 +12,11 @@
     return ThrowException(Exception::TypeError(String::New("Argument " #I " must be a bool")));      \
   bool VAR = args[I]->IsTrue();
 
+#define REQ_INT_ARG(I, VAR)                                                                         \
+  if (args.Length() <= (I) || !args[I]->IsNumber())                                                 \
+    return ThrowException(Exception::TypeError(String::New("Argument " #I " must be an integer")));      \
+  int VAR = args[I]->NumberValue();
+
 #define REQ_STRING_ARG(I, VAR)                                                                       \
   if (args.Length() <= (I) || !args[I]->IsString())                                                  \
     return ThrowException(Exception::TypeError(String::New("Argument " #I " must be a string")));    \


### PR DESCRIPTION
The prefetch row count option can make a big difference on performance, especially with high latency connection. 
By setting it to 100, I decreased processing time from 340s to 80s in my oracle test. 
