### PR TITLE
fixed memory leak on input parameters

### DIFF
--- a/src/executeBaton.cpp
+++ b/src/executeBaton.cpp
@@ -27,8 +27,16 @@ ExecuteBaton::~ExecuteBaton() {
   for (std::vector<value_t*>::iterator iterator = values.begin(), end = values.end(); iterator != end; ++iterator) {
 
     value_t* val = *iterator;
-    if(val->type == VALUE_TYPE_STRING) {
-      delete (std::string*)val->value;
+    switch (val->type) {
+      case VALUE_TYPE_STRING:
+        delete (std::string*)val->value;
+        break;
+      case VALUE_TYPE_NUMBER:
+        delete (oracle::occi::Number*)val->value;
+        break;
+      case VALUE_TYPE_TIMESTAMP:
+        delete (oracle::occi::Timestamp*)val->value;
+        break;
     }
     delete val;
   }


### PR DESCRIPTION
@joeferner I had stressed read operations before. Now I'm stressing writes and found this memory leak (was easy to fix). With this fix I get flat memory usage with processes that write for more than an hour.

Might be worth publishing a new version to NPM as the recent PRs fixed memory leaks.
