### PR TITLE
Added generic exception catcher to baton->createConnection

### DIFF
--- a/src/oracle_bindings.cpp
+++ b/src/oracle_bindings.cpp
@@ -127,6 +127,8 @@ void OracleClient::EIO_Connect(uv_work_t* req) {
     baton->connection = baton->environment->createConnection(baton->user, baton->password, connectionStr.str());
   } catch(oracle::occi::SQLException &ex) {
     baton->error = new std::string(ex.getMessage());
+  } catch (const std::exception& ex) {
+    baton->error = new std::string(ex.what());
   }
 }
 


### PR DESCRIPTION
Stops the application crashing due to connection issues - specifically this allowed us to see we had an issue with the TNS service name not being recognised on the server
