### PR TITLE
Implement a statement cache of 100 requests

### DIFF
--- a/src/oracle_bindings.cpp
+++ b/src/oracle_bindings.cpp
@@ -125,6 +125,7 @@ void OracleClient::EIO_Connect(uv_work_t* req) {
       connectionStr << "//" << baton->hostname << ":" << baton->port << "/" << baton->database;
     }
     baton->connection = baton->environment->createConnection(baton->user, baton->password, connectionStr.str());
+    baton->connection->setStmtCacheSize(100);
   } catch(oracle::occi::SQLException &ex) {
     baton->error = new std::string(ex.getMessage());
   } catch (const std::exception& ex) {


### PR DESCRIPTION
Fixes issue #10:
- 1-line code change is from user billywhizz
- Avoid compiling the SQL in the client every time you execute a statement
- This adds a statement cache with hardcoded size of 100; may want to make configurable at some point
