### PR TITLE
Made changes with OutParam::OCCICLOB bacause of problems with output cirillic chars

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -795,12 +795,13 @@ failed:
               output->clobVal.open(oracle::occi::OCCI_LOB_READONLY);
       				oracle::occi::Stream* instream = output->clobVal.getStream(1,0);
       				size_t chunkSize = output->clobVal.getChunkSize();
-      				char *buffer = new char[chunkSize];
+      				char *buffer = new char[chunkSize + 1];
       				memset(buffer, 0, chunkSize);
       				std::string clobVal;
       				int numBytesRead = instream->readBuffer(buffer, chunkSize);
       				int totalBytesRead = 0;
       				while (numBytesRead != -1) {
+                buffer[numBytesRead] = 0;
       					totalBytesRead += numBytesRead;
       					clobVal.append(buffer);
       					numBytesRead = instream->readBuffer(buffer, chunkSize);


### PR DESCRIPTION
I found a problem with output data with cyrillic chars from oracle. When output was large size (over ~2000 chars) i got unrecognized chars in clob. The settings are: NLS_LANG=.UTF8 (also tried AMERICAN_AMERICA.UTF8, AMERICAN_AMERICA.AL32UTF8.). After i made changes in connection.cpp it started work. :)  
