### PR TITLE
fix(CLOB): clob values had wrong values

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -802,7 +802,7 @@ failed:
       				int totalBytesRead = 0;
       				while (numBytesRead != -1) {
       					totalBytesRead += numBytesRead;
-      					clobVal.append(buffer);
+      					clobVal.append(buffer, numBytesRead);
       					numBytesRead = instream->readBuffer(buffer, chunkSize);
       				}
       				output->clobVal.closeStream(instream);


### PR DESCRIPTION
Appending to the result string now respects the read count.
