### PR TITLE
set explicit width for columns that report zero size

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -319,6 +319,8 @@ void Connection::CreateColumnsFromResultSet(oracle::occi::ResultSet* rs, Execute
       case oracle::occi::OCCI_TYPECODE_VARCHAR:
       case oracle::occi::OCCI_TYPECODE_CHAR:
         col->type = VALUE_TYPE_STRING;
+        if(metadata.getInt(oracle::occi::MetaData::ATTR_DATA_SIZE) == 0)
+          rs->setMaxColumnSize(columns.size() + 1, 1);
         break;
       case oracle::occi::OCCI_TYPECODE_CLOB:
         col->type = VALUE_TYPE_CLOB;
@@ -807,7 +809,7 @@ failed:
       				}
       				output->clobVal.closeStream(instream);
       				output->clobVal.close();
-      				obj->Set(String::New(returnParam.c_str()), String::New(clobVal.c_str(), totalBytesRead));				
+      				obj->Set(String::New(returnParam.c_str()), String::New(clobVal.c_str(), totalBytesRead));
       				delete [] buffer;
       				break;
             }


### PR DESCRIPTION
This fixes the issues I had related to this problem, mostly from queries like `select null from dual`. The metadata returns zero for the data size, setting it to 1 allows the queries to succeed

fixes #152
