### PR TITLE
Prerequisits for tests completed

### DIFF
--- a/test/outparams.js
+++ b/test/outparams.js
@@ -63,6 +63,13 @@
   END;
   /
 
+  CREATE OR REPLACE PROCEDURE procDateTimeOutParam(outParam1 OUT DATE, outParam2 OUT TIMESTAMP)
+  IS
+  BEGIN
+    select sysdate, systimestamp into outParam1, outParam2 from dual;
+  END;
+  /
+              
   BEGIN
      EXECUTE IMMEDIATE 'DROP TABLE basic_lob_table';
   EXCEPTION


### PR DESCRIPTION
To run the test for date and datetime outparams
an additional database procedure is needed.
