### PR TITLE
Statement object may be unreferenced and destructed before result callback is being fired

### DIFF
--- a/src/executeBaton.cpp
+++ b/src/executeBaton.cpp
@@ -268,7 +268,7 @@ void ExecuteBaton::GetVectorParam(ExecuteBaton* baton, arrayParam_t* arrParam, L
 
       // JS numbers can exceed oracle numbers, make sure this is not the case.
       double d = currVal->ToNumber()->Value();
-      if (d > 9.99999999999999999999999999999999999999*std::pow(10, 125) || d < -9.99999999999999999999999999999999999999*std::pow(10, 125)) {
+      if (d > 9.99999999999999999999999999999999999999*std::pow(double(10), double(125)) || d < -9.99999999999999999999999999999999999999*std::pow(double(10), double(125))) {
         std::ostringstream message;
         message << "Input array has number that is out of the range of Oracle numbers, check the number at index " << i;
         baton->error = new std::string(message.str());


### PR DESCRIPTION
This following code crashes on Win7, Mac OS 10.10 and CentOS 6.3

``` javascript
oracle.connect(connectData, function (error, connection) {

var statement;
for (var i = 0; i < 1000; i++) {
    statement = connection.prepare('SELECT * FROM DUAL');
    statement.execute([], function (err, result) {
        // statement object might already be garbage collected by now.. 
        // when it does it will crash
    });
}

}
```

statement.cpp line 25

``` C++
Statement::~Statement() {
  delete m_baton;
  m_baton = NULL;
}
```

delete m_baton might be called because the statement could be unreferenced before EIO_AfterExecute will be called (line 87)

``` C++
req->data // garbage 
```

I also fixed ../src/executeBaton.cpp:271:123: error: call to 'pow' is ambiguous
made some problems when compiling under OS X 10.10
