### PR TITLE
setNumberStringFormat introduction

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -92,6 +92,7 @@ public:
   static uni::CallbackType Rollback(const uni::FunctionCallbackInfo& args);
   static uni::CallbackType SetAutoCommit(const uni::FunctionCallbackInfo& args);
   static uni::CallbackType SetPrefetchRowCount(const uni::FunctionCallbackInfo& args);
+  static uni::CallbackType setNumberStringFormat(const uni::FunctionCallbackInfo& args);  
   static Persistent<FunctionTemplate> constructorTemplate;
   static void EIO_Execute(uv_work_t* req);
   static void EIO_AfterExecute(uv_work_t* req, int status);
@@ -106,6 +107,7 @@ public:
 
   void setConnection(oracle::occi::Environment* environment, oracle::occi::Connection* connection);
   oracle::occi::Environment* getEnvironment() { return m_environment; }
+  std::string* getNumberStringFormat( ) { return m_numberStringFormat; }  
 
 protected:
   // shared with Statement
@@ -130,6 +132,7 @@ private:
   oracle::occi::Environment* m_environment;
   bool m_autoCommit;
   int m_prefetchRowCount;
+  std::string* m_numberStringFormat;  
 };
 
 #endif

--- a/src/executeBaton.h
+++ b/src/executeBaton.h
@@ -24,7 +24,8 @@ enum {
   VALUE_TYPE_TIMESTAMP = 6,
   VALUE_TYPE_CLOB = 7,
   VALUE_TYPE_BLOB = 8,
-  VALUE_TYPE_ARRAY = 9
+  VALUE_TYPE_ARRAY = 9,
+  VALUE_TYPE_INUMBER = 10
 };
 
 struct column_t {


### PR DESCRIPTION
hi,
My need is to have decimal values like it are in the database without any alteration due to the approximation.
For example :
In a database number field, I could have :
249,199999999998
249,19999999998
249,1999999998
When i try to retrieved it from the database, i get in JS number 
249.19999999999803
249.19999999998
249.19999999979999
Well, the result is not safe.
The most safe solution is to retrieve it as string.
So, I introduced setNumberStringFormat option for the connection object . You can set format for decimal number as "99999999999999.99999999999999" for example.

cnx.setNumberStringFormat( "99999999999999.99999999999999" );

When it is set, number value are retrieved as string without alteration :
249,19999999999800
249,19999999998000
249,19999999980000
That's allow me to transform these string values in my own javascript BCD format.
I splited integer type (Integer/smallint) from the other number types, but, it's not usefull because oracle create smallint and integer as number(38) type.
It's possible to switch off the option by assigning an empty string in format.
cnx.setNumberStringFormat("");

Thanks to watch my request
