### PR TITLE
Fix: OCI_INC_DIR variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,7 @@ MacOS/Linux:
 export OCI_HOME=<directory of Oracle instant client>
 export OCI_LIB_DIR=$OCI_HOME
 export OCI_INCLUDE_DIR=$OCI_HOME/sdk/include
+export OCI_INC_DIR=$OCI_INCLUDE_DIR
 export OCI_VERSION=<the instant client major version number> # Optional. Default is 11.
 export NLS_LANG=AMERICAN_AMERICA.UTF8
 ```


### PR DESCRIPTION
Hello guys!

I had a problem with building without OCI_INC_DIR variable on mac os x yo:

  CXX(target) Release/obj.target/oracledb/src/njs/src/njsOracle.o
In file included from ../src/njs/src/njsOracle.cpp:53:
In file included from ../src/njs/src/njsOracle.h:63:
In file included from ../src/dpi/include/dpi.h:35:
In file included from ../src/dpi/include/dpiEnv.h:37:
In file included from ../src/dpi/include/dpiPool.h:33:
In file included from ../src/dpi/include/dpiConn.h:33:
../src/dpi/include/dpiStmt.h:29:11: fatal error: 'oci.h' file not found
# include <oci.h>

```
      ^
```

1 error generated.
make: **\* [Release/obj.target/oracledb/src/njs/src/njsOracle.o] Error 1

thx
